### PR TITLE
Symfony component Yaml has deprecated Yaml::parse

### DIFF
--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -11,7 +11,7 @@ class YamlConfigDriver implements ConfigDriver
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse($filename);
+        $config = Yaml::parse(file_get_contents($filename));
         return $config ?: array();
     }
 


### PR DESCRIPTION
this code avoids deprecated error message in current version.
